### PR TITLE
Don't try to upgrade new installations

### DIFF
--- a/uiDivStats.sh
+++ b/uiDivStats.sh
@@ -1483,7 +1483,7 @@ Process_Upgrade(){
 
 	rm -f "$SCRIPT_DIR/.newindexes"
 
-	if [ ! -f "$SCRIPT_DIR/.newallowed" ]; then
+	if [ echo "SELECT [Result] FROM [dnsqueries] LIMIT 0" | "$SQLITE3_PATH" "$DNS_DB" >/dev/null 2>&1 ]; then
 		Print_Output true "Upgrading database schema, this will take a while!" "$WARN"
 
 		/opt/etc/init.d/S90taildns stop >/dev/null 2>&1
@@ -1512,7 +1512,6 @@ Process_Upgrade(){
 
 		Auto_Cron create 2>/dev/null
 		/opt/etc/init.d/S90taildns start >/dev/null 2>&1
-		touch "$SCRIPT_DIR/.newallowed"
 	fi
 }
 


### PR DESCRIPTION
If someone runs `uiDivStats` without arguments on a new installation, it will try to upgrade, which will fail. Because all sqlite commands run in a while loop (I don't know why), it will keep trying indefinitely.

Instead of trying to guess whether the upgrade is necessary, it's safer to just check if the old `Result` column exists.