### PR TITLE
Rename type=65 to HTTPS

### DIFF
--- a/taildns.d/dnsmasqtotal-a-aaaa.awk
+++ b/taildns.d/dnsmasqtotal-a-aaaa.awk
@@ -4,7 +4,7 @@ BEGIN {
 	OFS = ",";
 }
 {
-	if ($5 ~ "query\\[A" && $5 !~ "dnssec"){
+	if ($5 ~ "query\\[(A|AAAA|HTTPS)\\]" && $5 !~ "dnssec"){
 		time = mktime( \
 			sprintf("%04d %02d %02d %s\n", \
 				strftime("%Y", systime()), \

--- a/taildns.d/dnsmasqtotalextra-a-aaaa.awk
+++ b/taildns.d/dnsmasqtotalextra-a-aaaa.awk
@@ -4,7 +4,7 @@ BEGIN {
 	OFS = ",";
 }
 {
-	if ($7 ~ "query\\[A" && $7 !~ "dnssec"){
+	if ($7 ~ "query\\[(A|AAAA|HTTPS)\\]" && $7 !~ "dnssec"){
 		time = mktime( \
 			sprintf("%04d %02d %02d %s\n", \
 				strftime("%Y", systime()), \

--- a/taildns.d/taildnstotal
+++ b/taildns.d/taildnstotal
@@ -5,7 +5,7 @@ trap '' SIGHUP
 
 querymode="$(grep "QUERYMODE" /jffs/addons/uiDivStats.d/config | cut -f2 -d"=")"
 tailfilesuffix=""
-if [ "$querymode" = "A+AAAA" ]; then
+if [ "$querymode" = "A+AAAA" ] || [ "$querymode" = "A+AAAA+HTTPS" ]; then
 	tailfilesuffix="-a-aaaa"
 fi
 

--- a/taildns.d/taildnstotal-cache
+++ b/taildns.d/taildnstotal-cache
@@ -5,7 +5,7 @@ trap '' SIGHUP
 
 querymode="$(grep "QUERYMODE" /jffs/addons/uiDivStats.d/config | cut -f2 -d"=")"
 tailfilesuffix=""
-if [ "$querymode" = "A+AAAA" ]; then
+if [ "$querymode" = "A+AAAA" ] || [ "$querymode" = "A+AAAA+HTTPS" ]; then
 	tailfilesuffix="-a-aaaa"
 fi
 

--- a/uiDivStats.sh
+++ b/uiDivStats.sh
@@ -1495,7 +1495,7 @@ Process_Upgrade(){
 		{
 			echo "ALTER TABLE [dnsqueries] RENAME TO [dnsqueries_bak];"
 			echo "CREATE TABLE [dnsqueries] ([QueryID] INTEGER PRIMARY KEY NOT NULL,[Timestamp] NUMERIC NOT NULL,[SrcIP] TEXT NOT NULL,[ReqDmn] TEXT NOT NULL,[QryType] Text NOT NULL,[Allowed] INTEGER NOT NULL);"
-			echo "INSERT INTO [dnsqueries] SELECT [QueryID], [Timestamp], [SrcIP], [ReqDmn], [QryType], [Result] == 'allowed' FROM [dnsqueries_bak];"
+			echo "INSERT INTO [dnsqueries] SELECT [QueryID], [Timestamp], [SrcIP], [ReqDmn], CASE [QryType] WHEN 'type=65' THEN 'HTTPS' ELSE [QryType] END, [Result] == 'allowed' FROM [dnsqueries_bak];"
 			echo "DROP TABLE [dnsqueries_bak];"
 		} > /tmp/uidivstats-upgrade.sql
 		while ! "$SQLITE3_PATH" "$DNS_DB" < /tmp/uidivstats-upgrade.sql >/dev/null 2>&1; do

--- a/uiDivStats.sh
+++ b/uiDivStats.sh
@@ -421,6 +421,7 @@ Conf_Exists(){
 		if ! grep -q "LASTXQUERIES" "$SCRIPT_CONF"; then
 			echo "LASTXQUERIES=5000" >> "$SCRIPT_CONF"
 		fi
+		sed -i -e 's/QUERYMODE=A+AAAA$/QUERYMODE=A+AAAA+HTTPS/g' "$SCRIPT_CONF"
 		return 0
 	else
 		{ echo "QUERYMODE=all"; echo "CACHEMODE=tmp"; echo "DAYSTOKEEP=30"; echo "LASTXQUERIES=5000"; } > "$SCRIPT_CONF"
@@ -691,8 +692,8 @@ QueryMode(){
 			sleep 3
 			/opt/etc/init.d/S90taildns start >/dev/null 2>&1
 		;;
-		A+AAAA)
-			sed -i 's/^QUERYMODE.*$/QUERYMODE=A+AAAA/' "$SCRIPT_CONF"
+		A+AAAA+HTTPS)
+			sed -i 's/^QUERYMODE.*$/QUERYMODE=A+AAAA+HTTPS/' "$SCRIPT_CONF"
 			/opt/etc/init.d/S90taildns stop >/dev/null 2>&1
 			sleep 3
 			/opt/etc/init.d/S90taildns start >/dev/null 2>&1
@@ -1628,8 +1629,8 @@ MainMenu(){
 				printf "\\n"
 				if Check_Lock menu; then
 					if [ "$(QueryMode check)" = "all" ]; then
-						QueryMode "A+AAAA"
-					elif [ "$(QueryMode check)" = "A+AAAA" ]; then
+						QueryMode "A+AAAA+HTTPS"
+					elif [ "$(QueryMode check)" = "A+AAAA+HTTPS" ]; then
 						QueryMode all
 					fi
 					Clear_Lock

--- a/uiDivStats.sh
+++ b/uiDivStats.sh
@@ -1484,7 +1484,7 @@ Process_Upgrade(){
 
 	rm -f "$SCRIPT_DIR/.newindexes"
 
-	if [ echo "SELECT [Result] FROM [dnsqueries] LIMIT 0" | "$SQLITE3_PATH" "$DNS_DB" >/dev/null 2>&1 ]; then
+	if echo "SELECT [Result] FROM [dnsqueries] LIMIT 0" | "$SQLITE3_PATH" "$DNS_DB" >/dev/null 2>&1; then
 		Print_Output true "Upgrading database schema, this will take a while!" "$WARN"
 
 		/opt/etc/init.d/S90taildns stop >/dev/null 2>&1

--- a/uidivstats_www.asp
+++ b/uidivstats_www.asp
@@ -123,8 +123,8 @@ var $j=jQuery.noConflict(),maxNoChartsBlocked=6,currentNoChartsBlocked=0,maxNoCh
 <td class="settingvalue">
 <input type="radio" name="uidivstats_querymode" id="uidivstats_query_all" class="input" value="all" checked>
 <label for="uidivstats_query_all">All</label>
-<input type="radio" name="uidivstats_querymode" id="uidivstats_query_aaaaa" class="input" value="A+AAAA">
-<label for="uidivstats_query_aaaaa">A+AAAA only</label>
+<input type="radio" name="uidivstats_querymode" id="uidivstats_query_aaaaahttps" class="input" value="A+AAAA+HTTPS">
+<label for="uidivstats_query_aaaaahttps">A+AAAA+HTTPS only</label>
 </td>
 </tr>
 <tr class="even" id="rowcachemode">

--- a/uidivstats_www.asp
+++ b/uidivstats_www.asp
@@ -226,12 +226,12 @@ var $j=jQuery.noConflict(),maxNoChartsBlocked=6,currentNoChartsBlocked=0,maxNoCh
 <option value="0">All</option>
 <option value="1">A</option>
 <option value="2">AAAA</option>
-<option value="3">ANY</option>
-<option value="4">SRV</option>
-<option value="5">SOA</option>
-<option value="6">PTR</option>
-<option value="7">TXT</option>
-<option value="8">type=65</option>
+<option value="3">HTTPS</option>
+<option value="4">ANY</option>
+<option value="5">SRV</option>
+<option value="6">SOA</option>
+<option value="7">PTR</option>
+<option value="8">TXT</option>
 </select>
 </td>
 <td>


### PR DESCRIPTION
The `type=65` queries are called `HTTPS` in dnsmasq 2.87 and newer, which is included in asuswrt-merlin since 388.2.

I think that people that use the `QUERYMODE=A+AAAA` setting probably want all queries that are being used to resolve IPs, so I changed it to `A+AAAA+HTTPS`.